### PR TITLE
Remove noisy console.log

### DIFF
--- a/src/zoom.js
+++ b/src/zoom.js
@@ -47,7 +47,6 @@ export default class zoom {
           .attr('id', 'timeline-pf-zoom-out')
           .style('top', `${configuration.padding.top + dimensions.height - 26}px`)
           .on('click', () => {this.zoomClick()});
-          console.log(zoomIn.node().offsetWidth);
       zoomOut
         .style('left', `${configuration.padding.left + configuration.labelWidth + dimensions.width + (configuration.sliderWidth - zoomOut.node().offsetWidth)}px`)
         .append('i')


### PR DESCRIPTION
Unsure why this is here, it makes a bunch of noise though, proposing we remove this console.log statement so that consumers of timeline aren't bothered